### PR TITLE
styles(FE-22) Text, Textarea, Checkbox Update

### DIFF
--- a/src/BambeeSurvey.vue
+++ b/src/BambeeSurvey.vue
@@ -74,6 +74,12 @@ export default {
     defaultThemeColors['$text-color'] = theme.colors.black;
     SurveyVue.StylesManager.applyTheme();
 
+    this.model.css = {
+      checkbox: {
+        itemDecorator: 'sv-svg',
+      },
+    };
+
     // Other possible theme values to be declared:
     // $header-background-color: "#e7e7e7"
     // $header-color: "#6d7072"
@@ -123,6 +129,11 @@ export default {
     transition-all;
 }
 
+.base-survey.sv_main
+  .sv_body
+  .sv_p_root
+  .sv_q
+  input:not([type='button']):not([type='reset']):not([type='submit']):not([type='image']):not([type='checkbox']):not([type='radio']):hover,
 .base-survey.sv_main textarea:hover {
   @apply border-gray-3;
 }
@@ -143,13 +154,14 @@ export default {
 
 .base-survey.sv_main textarea:focus,
 .base-survey.sv_main .sv-boolean input:focus ~ .sv-boolean__switch,
+.base-survey.sv_main input[type='text']:focus,
 .base-survey.sv_main input[type='button']:focus,
 .base-survey.sv_main button:focus {
-  @apply outline-none shadow-outline;
+  @apply outline-none shadow-none border-primary;
 }
 
 .base-survey.sv_main .sv_container .sv_body .sv_p_root .sv_q textarea {
-  @apply appearance-none border-2 font-body-text font-sans p-4 rounded-md;
+  @apply appearance-none font-body-text font-sans p-4;
 }
 
 .base-survey.sv_main
@@ -205,5 +217,58 @@ export default {
   @apply absolute bg-primary block h-0 rounded-full w-1/2;
   content: '';
   padding-top: 50%;
+}
+
+.base-survey.sv_main .sv_body .sv_p_root .sv_q input[type='checkbox'] {
+  @apply hidden;
+}
+
+.base-survey.sv_main .sv_body .sv_q_checkbox .sv_q_checkbox_label {
+  @apply relative flex items-center;
+}
+
+.base-survey.sv_main .sv_body .sv_q_checkbox {
+  @apply mb-2;
+}
+
+.base-survey.sv_main .sv_body .sv_q_checkbox:last-child {
+  @apply mb-0 !important;
+}
+
+.base-survey.sv_main .sv_body .sv_q_checkbox .form-group {
+  @apply mt-4;
+}
+
+.base-survey.sv_main
+  .sv_body
+  .sv_q_checkbox
+  .sv_q_checkbox_label
+  > span:last-child {
+  @apply leading-6 pl-10;
+}
+
+.base-survey.sv_main
+  .sv_body
+  .sv_q_checkbox
+  .sv_q_checkbox_label
+  .checkbox-material {
+  @apply absolute left-0 w-6 h-6 flex items-center justify-center bg-white text-white border border-solid border-gray-4 rounded-md;
+}
+
+.base-survey.sv_main
+  .sv_body
+  .sv_q_checkbox
+  .sv_q_checkbox_label
+  .checkbox-material
+  .sv-svg {
+  @apply w-6 h-6 text-white fill-current;
+}
+
+.base-survey.sv_main
+  .sv_body
+  .sv_q_checkbox.checked
+  .sv_q_checkbox_label
+  .checkbox-material {
+  @apply bg-primary border-primary;
 }
 </style>

--- a/src/assets/surveys/HrAuditOnePage.json
+++ b/src/assets/surveys/HrAuditOnePage.json
@@ -4,6 +4,76 @@
       "name": "page1",
       "elements": [
         {
+          "name": "question8",
+          "type": "text",
+          "title": "What is your company's legal name?"
+        },
+        {
+          "name": "question65",
+          "type": "text",
+          "title": "What is the business' mailing address?"
+        },
+        {
+          "name": "question56",
+          "type": "comment",
+          "title": "Please list the policies you currently provide."
+        },
+        {
+          "name": "question4",
+          "type": "multipletext",
+          "items": [
+            {
+              "name": "text1",
+              "title": "Full name"
+            },
+            {
+              "name": "text2",
+              "title": "Preferred email "
+            }
+          ],
+          "title": "Who will be your company's primary point-of-contact",
+          "isRequired": true,
+          "description": "The point-of-contact will be the first person Bambee reaches out to regarding important items that effect your business"
+        },
+        {
+          "name": "question1",
+          "type": "checkbox",
+          "title": "There are many key areas that HR can cover to reinforce and protect your business. Which of the following areas can Bambee solve for you?",
+          "choices": [
+            {
+              "text": "Select All",
+              "value": "item1"
+            },
+            {
+              "text": "I want to mitigate risk",
+              "value": "item2"
+            },
+            {
+              "text": "I want to protect my business from unlawful claims",
+              "value": "item3"
+            },
+            {
+              "text": "I want to be able to hold my employees accountable",
+              "value": "item4"
+            },
+            {
+              "text": "I want reassurance that I'm making the right business decisions",
+              "value": "item5"
+            },
+            {
+              "text": "I want to create a better working environment",
+              "value": "item6"
+            },
+            {
+              "text": "I want my business to be compliant",
+              "value": "item7"
+            }
+          ],
+          "hasOther": true,
+          "noneText": "Other",
+          "otherText": "I want to be proactive and stay up to date with employment laws"
+        },
+        {
           "type": "boolean",
           "name": "hasRemoteWorkers",
           "title": "Do you have any remote workers?",


### PR DESCRIPTION
### Description
FE-12
https://bambee.atlassian.net/jira/software/projects/FE/boards/58?selectedIssue=FE-22

The current Bambee Survey has styles that are not consistent with our current Bambee/Pollen styles.  
1. Text and Textarea components should have consistent styles with each other.
2. Checkbox fill and border color are different from Bambee/Pollen styles: Currently have blue fill. 

### Images/Screenshots
Updated Checkbox Input:
![Screenshot_20210827_143531](https://user-images.githubusercontent.com/10406785/131191103-bbb95c09-bfce-4b86-8ccd-c6f27048c532.png)

Slight modification to Text and Textarea Inputs to match styles:
![Screenshot_20210827_143702](https://user-images.githubusercontent.com/10406785/131191155-dd5667dc-84bf-4b82-b03c-af163236ff09.png)


###  Implementation
The `default` theme sets the SVG item as hidden and uses the browser `input[type="checkbox"]`, which is difficult to style, to show the checkbox.  

Added `sv-svg` className to by using:
`this.model.css = {
  checkbox: {
    itemDecorator: 'sv-svg',
  }
}`  

this will insert the `sv-svg` className on to the SVG checkmark icon instead of hiding it, allowing us to style and use the SVG instead of the Browser Native `input[type="checkbox"]`.
